### PR TITLE
Bump version to v0.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 name = 'svreal'
-version = '0.2.0.dev1'
+version = '0.2.0'
 
 DESCRIPTION = '''\
 Library for working with fixed-point numbers in SystemVerilog\


### PR DESCRIPTION
This is a very minor PR -- previously the version was 0.2.0.dev1, now it's 0.2.0 so that the latest version will be installed from pip.