### PR TITLE
Fix precision issue in comparison

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 name = 'svreal'
-version = '0.2.1'
+version = '0.2.2'
 
 DESCRIPTION = '''\
 Library for working with fixed-point numbers in SystemVerilog\

--- a/svreal/svreal.sv
+++ b/svreal/svreal.sv
@@ -34,6 +34,9 @@ endfunction
 `define MAX_MATH(a, b) \
     (((``a``) > (``b``)) ? (``a``) : (``b``))
 
+`define MIN_MATH(a, b) \
+    (((``a``) < (``b``)) ? (``a``) : (``b``))
+
 `define ABS_MATH(a) \
     (((``a``) > 0) ? (``a``) : (-(``a``)))
 
@@ -747,12 +750,12 @@ module comp_real #(
     `INPUT_REAL(b),
     output wire logic c
 );
-	// compute the maximum of the two exponents and align both inputs to it
+	// compute the minimum of the two exponents and align both inputs to it
 
-    localparam integer max_exponent = `MAX_MATH(`EXPONENT_PARAM_REAL(a), `EXPONENT_PARAM_REAL(b));
+    localparam integer min_exponent = `MIN_MATH(`EXPONENT_PARAM_REAL(a), `EXPONENT_PARAM_REAL(b));
 
-    `REAL_FROM_WIDTH_EXP(a_aligned, `WIDTH_PARAM_REAL(a), max_exponent);
-    `REAL_FROM_WIDTH_EXP(b_aligned, `WIDTH_PARAM_REAL(b), max_exponent);
+    `REAL_FROM_WIDTH_EXP(a_aligned, (`WIDTH_PARAM_REAL(a))+(`EXPONENT_PARAM_REAL(a))-min_exponent, min_exponent);
+    `REAL_FROM_WIDTH_EXP(b_aligned, (`WIDTH_PARAM_REAL(b))+(`EXPONENT_PARAM_REAL(b))-min_exponent, min_exponent);
 
     `ASSIGN_REAL(a, a_aligned);
     `ASSIGN_REAL(b, b_aligned);


### PR DESCRIPTION
## Summary 
This PR fixes a sneaky bug that arises when comparing two values with different exponents.  Before, the two values were aligned to the larger (i.e., coarser) exponent, whereas now they are aligned to the smaller (i.e., smaller) exponent.  This results in a more accurate comparison than before, at the expense of more hardware.

## Example
To illustrate the issue, consider this seemingly innocuous code.  We expect the output will be ``0.9``, but it is actually ``0.0``.
```verilog
`MAKE_CONST_REAL(in, 0.9);
`MAKE_CONST_REAL(0.0, zero);
`MAX_REAL(in, zero, out);
```
The problem is that the constant ``zero`` has the exponent ``0``, meaning that ``in`` will essentially be cast to an integer (effectively ``$floor``) for this comparison.  So when ``in`` is aligned to the larger exponent (``0``), its value becomes ``0.0``.  The logic of `` `MAX_REAL `` then says "if ``in_aligned`` is greater than ``zero_aligned``, use ``in``;  otherwise use ``zero``".    Since ``in_aligned`` is _not_ greater than ``zero_aligned``, we use ``zero``, resulting in a huge error.

## Analysis
The drawback of the new approach is that it does create more hardware, since values have to be left-shifted into alignment as opposed to right-shifted.  While it would be tempting to just change "greater than" to "greater than or equal to" in `` `MAX_REAL ``, the problem reappears when the arguments are swapped, so that is not really a solution

The main alternative solution to the problem with `` `MAX_REAL `` would be to make the exponent for zero constants a really negative integer instead of `` 0 ``.  However, that might cause other issues if operations try to align to the more precise of two operands, and it seems unnecessary because the constant ``0.0`` can be represented with perfect accuracy using any exponent value.  Perhaps it would be better to have special handling of zero constants, but that seems messy.

My conclusion is that the proposed solution in this PR is the simplest and least likely to cause other problems, even though it may increase hardware utilization.