### PR TITLE
Add synchronous RAM macros to support runtime-updatable functions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 name = 'svreal'
-version = '0.2.2'
+version = '0.2.3'
 
 DESCRIPTION = '''\
 Library for working with fixed-point numbers in SystemVerilog\

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 name = 'svreal'
-version = '0.2.3'
+version = '0.2.4'
 
 DESCRIPTION = '''\
 Library for working with fixed-point numbers in SystemVerilog\

--- a/svreal/svreal.sv
+++ b/svreal/svreal.sv
@@ -936,7 +936,7 @@ module sync_ram_real #(
     // case because RAM data is always stored with fixed-point formatting,
     // even when FLOAT_REAL is defined.
     `ifdef FLOAT_REAL
-        assign din = `FLOAT_TO_FIXED(in, data_expt)
+        assign din = `FLOAT_TO_FIXED(in, data_expt);
         assign out = `FIXED_TO_FLOAT(dout, data_expt);
     `else
         localparam `RANGE_PARAM_REAL(din) = 2.0**(data_bits+data_expt-1);

--- a/svreal/svreal.sv
+++ b/svreal/svreal.sv
@@ -538,6 +538,30 @@ endfunction
     `REAL_FROM_WIDTH_EXP(out_name, data_bits_expr, data_expt_expr); \
     `SYNC_ROM_INTO_REAL(addr_name, out_name, clk_name, ce_name, addr_bits_expr, data_bits_expr, file_path_expr, data_expt_expr)
 
+// synchronous RAM
+
+`define SYNC_RAM_INTO_REAL(addr_name, in_name, out_name, clk_name, ce_name, we_name, addr_bits_expr, data_bits_expr, data_expt_expr) \
+    sync_ram_real #( \
+        `PASS_REAL(in, in_name), \
+        `PASS_REAL(out, out_name), \
+        .addr_bits(addr_bits_expr), \
+        .data_bits(data_bits_expr), \
+        .data_expt(data_expt_expr) \
+    ) sync_ram_real_``out_name``_i ( \
+        .addr(addr_name), \
+        .in(in_name), \
+        .out(out_name), \
+        .clk(clk_name), \
+        .ce(ce_name), \
+        .we(we_name) \
+    )
+
+`define SYNC_RAM_REAL(addr_name, in_name, out_name, clk_name, ce_name, we_name, addr_bits_expr, data_bits_expr, data_expt_expr) \
+    `REAL_FROM_WIDTH_EXP(out_name, data_bits_expr, data_expt_expr); \
+    `SYNC_RAM_INTO_REAL(addr_name, in_name, out_name, clk_name, ce_name, we_name, addr_bits_expr, data_bits_expr, data_expt_expr)
+
+// synchronous RAM
+
 // interface functions
 
 // range is not included as a parameter since there is no
@@ -873,6 +897,56 @@ module sync_rom_real #(
         localparam `WIDTH_PARAM_REAL(data) = data_bits;
         localparam `EXPONENT_PARAM_REAL(data) = data_expt;
         `ASSIGN_REAL(data, out);
+    `endif
+endmodule
+
+// adapted from the example on page 119-120 here:
+// https://www.xilinx.com/support/documentation/sw_manuals/xilinx2019_2/ug901-vivado-synthesis.pdf
+
+module sync_ram_real #(
+    `DECL_REAL(in),
+    `DECL_REAL(out),
+    parameter integer addr_bits=1,
+    parameter integer data_bits=1,
+    parameter integer data_expt=1
+) (
+    input wire logic [(addr_bits-1):0] addr,
+    `INPUT_REAL(in),
+    `OUTPUT_REAL(out),
+    input wire logic clk,
+    input wire logic ce,
+    input wire logic we
+);
+    // memory contents
+    logic signed [(data_bits-1):0] ram [((2**addr_bits)-1):0];
+    logic signed [(data_bits-1):0] din;
+    logic signed [(data_bits-1):0] dout;
+
+    // RAM I/O
+    always @(posedge clk) begin
+        if (ce) begin
+            if (we) begin
+                ram[addr] <= din;
+            end
+            dout <= ram[addr];
+        end
+    end
+
+    // Map in to din and dout to out.  We have to explicitly handle FLOAT_REAL
+    // case because RAM data is always stored with fixed-point formatting,
+    // even when FLOAT_REAL is defined.
+    `ifdef FLOAT_REAL
+        assign din = `FLOAT_TO_FIXED(in, data_expt)
+        assign out = `FIXED_TO_FLOAT(dout, data_expt);
+    `else
+        localparam `RANGE_PARAM_REAL(din) = 2.0**(data_bits+data_expt-1);
+        localparam `WIDTH_PARAM_REAL(din) = data_bits;
+        localparam `EXPONENT_PARAM_REAL(din) = data_expt;
+        `ASSIGN_REAL(in, din);
+        localparam `RANGE_PARAM_REAL(dout) = 2.0**(data_bits+data_expt-1);
+        localparam `WIDTH_PARAM_REAL(dout) = data_bits;
+        localparam `EXPONENT_PARAM_REAL(dout) = data_expt;
+        `ASSIGN_REAL(dout, out);
     `endif
 endmodule
 

--- a/tests/test_sync_ram.py
+++ b/tests/test_sync_ram.py
@@ -1,0 +1,62 @@
+# AHA imports
+import magma as m
+import fault
+
+# svreal imports
+from .common import pytest_sim_params, get_file
+from svreal import get_svreal_header
+
+def pytest_generate_tests(metafunc):
+    pytest_sim_params(metafunc)
+    metafunc.parametrize('defines', [{}, {'FLOAT_REAL': None}])
+
+def test_sync_ram(simulator, defines):
+    # declare circuit
+    class dut(m.Circuit):
+        name = 'test_sync_ram'
+        io = m.IO(
+            addr=m.In(m.Bits[2]),
+            in_=fault.RealIn,
+            out=fault.RealOut,
+            clk=m.ClockIn,
+            ce=m.BitIn,
+            we=m.BitIn,
+        )
+
+    # define the test
+    t = fault.Tester(dut, dut.clk)
+
+    # initialize
+    t.zero_inputs()
+    t.poke(dut.ce, 1)
+    t.step(2)
+
+    # write data
+
+    write_order = [1, 0, 3, 2]
+    write_data = [1.23, -2.34, 3.45, -4.56]
+
+    t.poke(dut.we, 1)
+    for addr in write_order:
+        t.poke(dut.addr, addr)
+        t.poke(dut.in_, write_data[addr])
+        t.step(2)
+
+    # read data
+
+    read_order = [0, 3, 2, 1]
+
+    t.poke(dut.we, 0)
+    for addr in read_order:
+        t.poke(dut.addr, addr)
+        t.step(2)
+        t.expect(dut.out, write_data[addr], abs_tol=0.001)
+
+    # run the test
+    t.compile_and_run(
+        target='system-verilog',
+        simulator=simulator,
+        ext_srcs=[get_file('test_sync_ram.sv')],
+        inc_dirs=[get_svreal_header().parent],
+        ext_model_file=True
+    )

--- a/tests/test_sync_ram.sv
+++ b/tests/test_sync_ram.sv
@@ -1,0 +1,22 @@
+`timescale 1ns / 1ps
+
+`include "svreal.sv"
+
+module test_sync_ram (
+    input [1:0] addr,
+    input real in_,
+    output real out,
+    input clk,
+    input ce,
+    input we
+);
+    // wire up the RAM input
+    `MAKE_REAL(in_int, 10);
+    assign `FORCE_REAL(in_, in_int);
+
+    // instantiate the RAM
+    `SYNC_RAM_REAL(addr, in_int, out_int, clk, ce, we, 2, 18, -12);
+
+    // wire up the RAM output
+    assign out = `TO_REAL(out_int);
+endmodule

--- a/tests/test_sync_ram.sv
+++ b/tests/test_sync_ram.sv
@@ -4,18 +4,14 @@
 
 module test_sync_ram (
     input [1:0] addr,
-    input real in_,
+    input signed [((`WIDTH)-1):0] din,
     output real out,
     input clk,
     input ce,
     input we
 );
-    // wire up the RAM input
-    `MAKE_REAL(in_int, 10);
-    assign `FORCE_REAL(in_, in_int);
-
     // instantiate the RAM
-    `SYNC_RAM_REAL(addr, in_int, out_int, clk, ce, we, 2, 18, -12);
+    `SYNC_RAM_REAL(addr, din, out_int, clk, ce, we, 2, `WIDTH, `EXPONENT);
 
     // wire up the RAM output
     assign out = `TO_REAL(out_int);


### PR DESCRIPTION
This PR adds the macros ``SYNC_RAM_REAL`` / ``SYNC_RAM_INTO_REAL``.  They are analogous to existing macros ``SYNC_ROM_REAL`` / ``SYNC_ROM_INTO_REAL``, except that the lookup table contents are defined at runtime rather than at compile time.  This feature is used in the [``update_bram``](https://github.com/sgherbst/msdsl/tree/update_bram) branch of msdsl to implement runtime-updatable functions; that is, functions whose behavior can be defined while the emulator is running, as opposed to requiring a rebuild of the bitstream.  The new feature is exercised in CI tests via ``tests/test_sync_ram.py``.