### PR TITLE
Add approximate logarithm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 name = 'svreal'
-version = '0.2.6.dev1'
+version = '0.2.6'
 
 DESCRIPTION = '''\
 Library for working with fixed-point numbers in SystemVerilog\

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 name = 'svreal'
-version = '0.2.5'
+version = '0.2.6.dev1'
 
 DESCRIPTION = '''\
 Library for working with fixed-point numbers in SystemVerilog\

--- a/tests/test_compress_uint.py
+++ b/tests/test_compress_uint.py
@@ -1,0 +1,79 @@
+# generic imports
+import numpy as np
+from math import log2, floor
+
+# AHA imports
+import magma as m
+
+# svreal imports
+from .common import *
+
+def pytest_generate_tests(metafunc):
+    pytest_sim_params(metafunc)
+    pytest_real_type_params(metafunc)
+
+    # set up test vectors
+    opts = []
+
+    # width 1
+    opts.append((1, list(range(2))))
+
+    # width 8
+    opts.append((8, list(range(256))))
+
+    # width 32
+    N = 32
+    vec = []
+
+    # specifically-chosen entries
+    for k in range(0, N-1):
+        vec.append((1<<k)-1)
+        vec.append((1<<k)+0)
+        vec.append((1<<k)+1)
+    vec.append((1<<(N-1))-1)
+    vec.append(1<<(N-1))
+
+    # pseudo-random entries chosen in a logarithmic fashion
+    # the random seed is chosen to make sure this test has
+    # consistent result in regression testing
+    np.random.seed(1)
+    rand_pts = 2**(np.random.uniform(0, N, 100))
+    rand_pts = np.floor(rand_pts).astype(np.int)
+    rand_pts = [int(elem) for elem in rand_pts]
+    vec += rand_pts
+
+    opts.append((N, vec))
+
+    metafunc.parametrize('width,test_vec', opts)
+
+def model_func(r):
+    if r == 0:
+        return 0
+    else:
+        x = int(floor(log2(r))) + 1
+        y = (r/(1<<(x-1))) - 1
+        return x + y
+
+def test_compress_uint(simulator, real_type, width, test_vec):
+    # declare circuit
+    class dut(m.Circuit):
+        name = 'test_compress_uint'
+        io = m.IO(
+            in_=m.In(m.Bits[width]),
+            out = fault.RealOut
+        )
+
+    # define the test
+    t = SvrealTester(dut)
+
+    for in_ in test_vec:
+        t.poke(dut.in_, in_)
+        t.eval()
+        t.expect(dut.out, model_func(in_), abs_tol=1e-5)
+
+    t.compile_and_run(
+        simulator=simulator,
+        ext_srcs=[get_file('test_compress_uint.sv')],
+        defines={'WIDTH': width},
+        real_type=real_type
+    )

--- a/tests/test_compress_uint.sv
+++ b/tests/test_compress_uint.sv
@@ -1,0 +1,15 @@
+`timescale 1ns/1ps
+
+`include "svreal.sv"
+
+`ifndef WIDTH
+    `define WIDTH 8
+`endif
+
+module test_compress_uint (
+    input [((`WIDTH)-1):0] in_,
+    output real out
+);
+    `COMPRESS_UINT(in_, (`WIDTH), val);
+    assign out = `TO_REAL(val);
+endmodule

--- a/tests/test_meas_width.py
+++ b/tests/test_meas_width.py
@@ -1,0 +1,39 @@
+# generic imports
+from math import log2, floor
+
+# AHA imports
+import magma as m
+
+# svreal imports
+from .common import *
+
+def pytest_generate_tests(metafunc):
+    pytest_sim_params(metafunc)
+
+def model_func(x):
+    if x==0:
+        return 0
+    else:
+        return int(floor(log2(x))) + 1
+
+def test_meas_width(simulator):
+    # declare circuit
+    class dut(m.Circuit):
+        name = 'test_meas_width'
+        io = m.IO(
+            in_=m.In(m.Bits[8]),
+            out = m.Out(m.Bits[8])
+        )
+
+    # define the test
+    t = SvrealTester(dut)
+
+    for in_ in range(256):
+        t.poke(dut.in_, in_)
+        t.eval()
+        t.expect(dut.out, model_func(in_))
+
+    t.compile_and_run(
+        simulator=simulator,
+        ext_srcs=[get_file('test_meas_width.sv')]
+    )

--- a/tests/test_meas_width.sv
+++ b/tests/test_meas_width.sv
@@ -1,0 +1,10 @@
+`timescale 1ns/1ps
+
+`include "svreal.sv"
+
+module test_meas_width (
+    input [7:0] in_,
+    output [7:0] out
+);
+    `MEAS_UINT_WIDTH_INTO(in_, 8, out, 8);
+endmodule

--- a/tests/test_synth.sv
+++ b/tests/test_synth.sv
@@ -31,6 +31,9 @@ module test_synth (
     output wire logic le_ext,
     output wire logic gt_ext,
     output wire logic ge_ext,
+    // compression I/O
+    input wire logic [31:0] compress_i_ext,
+    output wire logic [((`LONG_WIDTH_REAL)-1):0] compress_o_ext,
     // control I/O
     input wire logic sel_ext,
     input wire logic rst_ext,
@@ -92,4 +95,8 @@ module test_synth (
     `LE_INTO_REAL(a, b, le_ext);
     `GT_INTO_REAL(a, b, gt_ext);
     `GE_INTO_REAL(a, b, ge_ext);
+
+    // uint compression
+    `COMPRESS_UINT(compress_i_ext, $size(compress_i_ext), compress_o);
+    assign compress_o_ext = compress_o;
 endmodule


### PR DESCRIPTION
This PR adds a new macro called `COMPRESS_UINT`.  Its output is the approximate logarithm of its input, plus one:
```
y = floor(log2(x)) + x/(2**(floor(log2(x))))
```
This macro, in combination with the **msdsl**'s arbitrary function feature, can allow for quite accurate implementations of logarithm-like functions on an FPGA.