### PR TITLE
Add Verilator support

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Update pip
       run: python -m pip install --upgrade pip
     - name: Install dependencies
-      run: sudo apt-get install g++-7 libgmp-dev libmpfr-dev libmpc-dev iverilog
+      run: sudo apt-get install g++-7 libgmp-dev libmpfr-dev libmpc-dev iverilog verilator
     - name: Run regression test
       env:
         CC: gcc-7
@@ -43,7 +43,7 @@ jobs:
       run: python -m pip install --upgrade pip
     - name: Install dependencies
       run: |
-        brew install icarus-verilog wget coreutils
+        brew install icarus-verilog verilator wget coreutils
     - name: Run regression test
       run: source regress.sh
     - name: Upload coverage

--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ To test **svreal**, please make sure that at least one of the following simulato
 2. ncsim
 3. vcs
 4. iverilog
+5. verilator
 
 Then make sure that **pytest** is installed.  If it's not, run the following command:
 ```shell

--- a/regress.sh
+++ b/regress.sh
@@ -9,14 +9,7 @@ pip install -e .
 pip install pysmt==0.9.0
 
 # install testing dependencies
-pip install pytest pytest-cov magma-lang==2.1.20 coreir==2.0.128 mantle==2.0.15 hwtypes==1.4.4 ast_tools==0.0.30 kratos==0.0.31.2
-
-# install fault
-git clone https://github.com/leonardt/fault.git
-cd fault
-git checkout verilator_real
-pip install -e .
-cd ..
+pip install pytest pytest-cov fault==3.0.43 magma-lang==2.1.20 coreir==2.0.128 mantle==2.0.15 hwtypes==1.4.4 ast_tools==0.0.30 kratos==0.0.31.2
 
 # run tests
 pytest --cov-report=xml --cov=svreal tests/ -v -r s

--- a/regress.sh
+++ b/regress.sh
@@ -9,7 +9,14 @@ pip install -e .
 pip install pysmt==0.9.0
 
 # install testing dependencies
-pip install pytest pytest-cov fault==3.0.36 magma-lang==2.1.17 coreir==2.0.120 mantle==2.0.10 hwtypes==1.4.3 ast_tools==0.0.30 kratos==0.0.31.1
+pip install pytest pytest-cov magma-lang==2.1.20 coreir==2.0.120 mantle==2.0.15 hwtypes==1.4.4 ast_tools==0.0.30 kratos==0.0.31.2
+
+# install fault
+git clone https://github.com/leonardt/fault.git
+cd fault
+git checkout verilator_real
+pip install -e .
+cd ..
 
 # run tests
 pytest --cov-report=xml --cov=svreal tests/ -v -r s

--- a/regress.sh
+++ b/regress.sh
@@ -9,7 +9,7 @@ pip install -e .
 pip install pysmt==0.9.0
 
 # install testing dependencies
-pip install pytest pytest-cov magma-lang==2.1.20 coreir==2.0.120 mantle==2.0.15 hwtypes==1.4.4 ast_tools==0.0.30 kratos==0.0.31.2
+pip install pytest pytest-cov magma-lang==2.1.20 coreir==2.0.128 mantle==2.0.15 hwtypes==1.4.4 ast_tools==0.0.30 kratos==0.0.31.2
 
 # install fault
 git clone https://github.com/leonardt/fault.git

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 name = 'svreal'
-version = '0.2.7.dev1'
+version = '0.2.7'
 
 DESCRIPTION = '''\
 Library for working with fixed-point numbers in SystemVerilog\

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 name = 'svreal'
-version = '0.2.6'
+version = '0.2.7.dev1'
 
 DESCRIPTION = '''\
 Library for working with fixed-point numbers in SystemVerilog\

--- a/svreal/svreal.sv
+++ b/svreal/svreal.sv
@@ -54,23 +54,22 @@ function int clog2_math(input real x);
     end
 endfunction
 
-`define CALC_EXP(range, width) \
-    (clog2_math((real'(``range``))/((2.0**((``width``)-1))-1.0)))
+`define CALC_EXP(range, width) (clog2_math((real'(range))/((2.0**((width)-1))-1.0)))
 
 `define MAX_MATH(a, b) \
-    (((``a``) > (``b``)) ? (``a``) : (``b``))
+    (((a) > (b)) ? (a) : (b))
 
 `define MIN_MATH(a, b) \
-    (((``a``) < (``b``)) ? (``a``) : (``b``))
+    (((a) < (b)) ? (a) : (b))
 
 `define ABS_MATH(a) \
-    (((``a``) > 0) ? (``a``) : (-(``a``)))
+    (((a) > 0) ? (a) : (-(a)))
 
 `define FIXED_TO_FLOAT(significand, exponent) \
-    ((``significand``)*(2.0**(``exponent``)))
+    ((significand)*(2.0**(exponent)))
 
 `define FLOAT_TO_FIXED(value, exponent) \
-    ((real'(``value``))*(2.0**(-(``exponent``))))
+    ((real'(value))*(2.0**(-(exponent))))
 
 // convert the HardFloat recoded format to a real number
 function real recfn2real(input logic [((`HARD_FLOAT_EXP_WIDTH)+(`HARD_FLOAT_SIG_WIDTH)):0] in);
@@ -219,7 +218,7 @@ endfunction
 `define EXPONENT_PARAM_REAL(name) ``name``_exponent_val
 
 `define PRINT_FORMAT_REAL(name) \
-    $display(`"``name``: {width=%0d, exponent=%0d, range=%0f}`", `WIDTH_PARAM_REAL(``name``), `EXPONENT_PARAM_REAL(``name``), `RANGE_PARAM_REAL(``name``))
+    $display(`"``name``: {width=%0d, exponent=%0d, range=%0f}`", `WIDTH_PARAM_REAL(name), `EXPONENT_PARAM_REAL(name), `RANGE_PARAM_REAL(name))
 
 // real number representation type
 
@@ -229,70 +228,68 @@ endfunction
     `elsif HARD_FLOAT \
         logic [(`HARD_FLOAT_SIGN_BIT):0] \
     `else \
-        logic signed [((``width_expr``)-1):0] \
+        logic signed [((width_expr)-1):0] \
     `endif
             
 // module ports
 
 `define DECL_REAL(port) \
-    parameter real `RANGE_PARAM_REAL(``port``) = 0, \
-    parameter integer `WIDTH_PARAM_REAL(``port``) = 0, \
-    parameter integer `EXPONENT_PARAM_REAL(``port``) = 0
+    parameter real `RANGE_PARAM_REAL(port) = 0, \
+    parameter integer `WIDTH_PARAM_REAL(port) = 0, \
+    parameter integer `EXPONENT_PARAM_REAL(port) = 0
 
 `define PASS_REAL(port, name) \
-    .`RANGE_PARAM_REAL(``port``)(`RANGE_PARAM_REAL(``name``)), \
-    .`WIDTH_PARAM_REAL(``port``)(`WIDTH_PARAM_REAL(``name``)), \
-    .`EXPONENT_PARAM_REAL(``port``)(`EXPONENT_PARAM_REAL(``name``))
+    .`RANGE_PARAM_REAL(port)(`RANGE_PARAM_REAL(name)), \
+    .`WIDTH_PARAM_REAL(port)(`WIDTH_PARAM_REAL(name)), \
+    .`EXPONENT_PARAM_REAL(port)(`EXPONENT_PARAM_REAL(name))
 
 `define PORT_REAL(port) \
     `ifdef FLOAT_REAL \
-        `DATA_TYPE_REAL(`WIDTH_PARAM_REAL(``port``)) ``port`` \
+        `DATA_TYPE_REAL(`WIDTH_PARAM_REAL(port)) port \
     `else \
-        wire `DATA_TYPE_REAL(`WIDTH_PARAM_REAL(``port``)) ``port`` \
+        wire `DATA_TYPE_REAL(`WIDTH_PARAM_REAL(port)) port \
     `endif
 
-`define INPUT_REAL(port) \
-    input `PORT_REAL(``port``)
+`define INPUT_REAL(port) input `PORT_REAL(port)
 
-`define OUTPUT_REAL(port) \
-    output `PORT_REAL(``port``)
+`define OUTPUT_REAL(port) output `PORT_REAL(port)
 
 // Displaying real number signals
 
 `define TO_REAL(name) \
     `ifdef FLOAT_REAL \
-        (``name``) \
+        (name) \
     `elsif HARD_FLOAT \
-        (`REC_FN_TO_REAL(``name``)) \
+        (`REC_FN_TO_REAL(name)) \
     `else \
-		(`FIXED_TO_FLOAT((``name``), (`EXPONENT_PARAM_REAL(``name``)))) \
+		(`FIXED_TO_FLOAT((name), (`EXPONENT_PARAM_REAL(name)))) \
     `endif
 
 `define PRINT_REAL(name) \
-    $display(`"``name``=%0f`", `TO_REAL(``name``))
+    $display(`"``name``=%0f`", `TO_REAL(name))
 
 // force a real number
 
 `define FROM_REAL(expr, name) \
     `ifdef FLOAT_REAL \
-        (``expr``) \
+        (expr) \
     `elsif HARD_FLOAT \
-        (`REAL_TO_REC_FN(``expr``)) \
+        (`REAL_TO_REC_FN(expr)) \
     `else \
-		(`FLOAT_TO_FIXED((``expr``), (`EXPONENT_PARAM_REAL(``name``)))) \
+		(`FLOAT_TO_FIXED((expr), (`EXPONENT_PARAM_REAL(name)))) \
     `endif
 
 `define FORCE_REAL(expr, name) \
-    ``name`` = `FROM_REAL(``expr``, ``name``)
+    name = `FROM_REAL(expr, name)
 
 // assert that real number is within specified range
 
 `define ASSERTION_REAL(in_name) \
     assertion_real #( \
-        `PASS_REAL(in, ``in_name``), \
+        `PASS_REAL(in, in_name), \
         .name(`"``in_name```") \
     ) assertion_real_``in_name``_i ( \
-        .in(``in_name``) \
+        .in(in_name) \
     )
 
 // creating real numbers
@@ -300,24 +297,24 @@ endfunction
 // and dont_touch can be used
 
 `define MAKE_FORMAT_REAL(name, range_expr, width_expr, exponent_expr) \
-    `DATA_TYPE_REAL(``width_expr``) ``name``; \
-    localparam real `RANGE_PARAM_REAL(``name``) = ``range_expr``; \
-    localparam integer `WIDTH_PARAM_REAL(``name``) = ``width_expr``; \
-    localparam integer `EXPONENT_PARAM_REAL(``name``) = ``exponent_expr`` \
+    `DATA_TYPE_REAL(width_expr) name; \
+    localparam real `RANGE_PARAM_REAL(name) = range_expr; \
+    localparam integer `WIDTH_PARAM_REAL(name) = width_expr; \
+    localparam integer `EXPONENT_PARAM_REAL(name) = exponent_expr \
     `ifdef RANGE_ASSERTIONS \
-        ; `ASSERTION_REAL(``name``) \
+        ; `ASSERTION_REAL(name) \
     `endif
 
 `define REAL_FROM_WIDTH_EXP(name, width_expr, exponent_expr) \
-    `MAKE_FORMAT_REAL(``name``, 2.0**((``width_expr``)+(``exponent_expr``)-1), ``width_expr``, ``exponent_expr``)
+    `MAKE_FORMAT_REAL(name, 2.0**((width_expr)+(exponent_expr)-1), width_expr, exponent_expr)
 
 // copying real number format
 
 `define GET_FORMAT_REAL(in_name) \
-    `DATA_TYPE_REAL(`WIDTH_PARAM_REAL(``in_name``))
+    `DATA_TYPE_REAL(`WIDTH_PARAM_REAL(in_name))
 
 `define COPY_FORMAT_REAL(in_name, out_name) \
-    `MAKE_FORMAT_REAL(``out_name``, `RANGE_PARAM_REAL(``in_name``), `WIDTH_PARAM_REAL(``in_name``), `EXPONENT_PARAM_REAL(``in_name``))
+    `MAKE_FORMAT_REAL(out_name, `RANGE_PARAM_REAL(in_name), `WIDTH_PARAM_REAL(in_name), `EXPONENT_PARAM_REAL(in_name))
 
 // negation
 // note that since the range of a fixed-point number is defined as +/- |range|, the negation of 
@@ -325,46 +322,46 @@ endfunction
 
 `define NEGATE_INTO_REAL(in_name, out_name) \
     negate_real #( \
-        `PASS_REAL(in, ``in_name``), \
-        `PASS_REAL(out, ``out_name``) \
+        `PASS_REAL(in, in_name), \
+        `PASS_REAL(out, out_name) \
     ) negate_real_``out_name``_i ( \
-        .in(``in_name``), \
-        .out(``out_name``) \
+        .in(in_name), \
+        .out(out_name) \
     ) 
 
 `define NEGATE_REAL(in_name, out_name) \
-    `COPY_FORMAT_REAL(``in_name``, ``out_name``); \
-    `NEGATE_INTO_REAL(``in_name``, ``out_name``)
+    `COPY_FORMAT_REAL(in_name, out_name); \
+    `NEGATE_INTO_REAL(in_name, out_name)
 
 // absolute value
 
 `define ABS_INTO_REAL(in_name, out_name) \
     abs_real #( \
-        `PASS_REAL(in, ``in_name``), \
-        `PASS_REAL(out, ``out_name``) \
+        `PASS_REAL(in, in_name), \
+        `PASS_REAL(out, out_name) \
     ) abs_real_``out_name``_i ( \
-        .in(``in_name``), \
-        .out(``out_name``) \
+        .in(in_name), \
+        .out(out_name) \
     ) 
 
 `define ABS_REAL(in_name, out_name) \
-    `COPY_FORMAT_REAL(``in_name``, ``out_name``); \
-    `ABS_INTO_REAL(``in_name``, ``out_name``)
+    `COPY_FORMAT_REAL(in_name, out_name); \
+    `ABS_INTO_REAL(in_name, out_name)
 
 // construct real number from range
 // the following four macros depend on clog2_math
 
 `define MAKE_GENERIC_REAL(name, range_expr, width_expr) \
-    `MAKE_FORMAT_REAL(``name``, ``range_expr``, ``width_expr``, `CALC_EXP(``range_expr``, ``width_expr``))
+    `MAKE_FORMAT_REAL(name, range_expr, width_expr, `CALC_EXP(range_expr, width_expr))
 
 `define MAKE_SHORT_REAL(name, range_expr) \
-    `MAKE_GENERIC_REAL(``name``, ``range_expr``, `SHORT_WIDTH_REAL)
+    `MAKE_GENERIC_REAL(name, range_expr, `SHORT_WIDTH_REAL)
 
 `define MAKE_LONG_REAL(name, range_expr) \
-    `MAKE_GENERIC_REAL(``name``, ``range_expr``, `LONG_WIDTH_REAL)
+    `MAKE_GENERIC_REAL(name, range_expr, `LONG_WIDTH_REAL)
 
 `define MAKE_REAL(name, range_expr) \
-    `MAKE_LONG_REAL(``name``, ``range_expr``)
+    `MAKE_LONG_REAL(name, range_expr)
     
 // assigning real numbers
 // note that the negative version of each number will already have be assigned when
@@ -372,11 +369,11 @@ endfunction
 
 `define ASSIGN_REAL(in_name, out_name) \
     assign_real #( \
-        `PASS_REAL(in, ``in_name``), \
-        `PASS_REAL(out, ``out_name``) \
+        `PASS_REAL(in, in_name), \
+        `PASS_REAL(out, out_name) \
     ) assign_real_``out_name``_i ( \
-        .in(``in_name``), \
-        .out(``out_name``) \
+        .in(in_name), \
+        .out(out_name) \
     ) 
 
 // real constants
@@ -384,72 +381,72 @@ endfunction
 // fixed-point representation falls within the range
 
 `define ASSIGN_CONST_REAL(const_expr, name) \
-    assign ``name`` = `FROM_REAL(``const_expr``, ``name``)
+    assign name = `FROM_REAL(const_expr, name)
 
 `define CONST_RANGE_REAL(const_expr) \
-    (1.01*`ABS_MATH(``const_expr``))
+    (1.01*`ABS_MATH(const_expr))
 
 `define MAKE_GENERIC_CONST_REAL(const_expr, name, width_expr) \
-    `MAKE_GENERIC_REAL(``name``, `CONST_RANGE_REAL(``const_expr``), ``width_expr``); \
-    `ASSIGN_CONST_REAL(``const_expr``, ``name``)
+    `MAKE_GENERIC_REAL(name, `CONST_RANGE_REAL(const_expr), width_expr); \
+    `ASSIGN_CONST_REAL(const_expr, name)
 
 `define MAKE_SHORT_CONST_REAL(const_expr, name) \
-    `MAKE_GENERIC_CONST_REAL(``const_expr``, ``name``, `SHORT_WIDTH_REAL)
+    `MAKE_GENERIC_CONST_REAL(const_expr, name, `SHORT_WIDTH_REAL)
 
 `define MAKE_LONG_CONST_REAL(const_expr, name) \
-    `MAKE_GENERIC_CONST_REAL(``const_expr``, ``name``, `LONG_WIDTH_REAL)
+    `MAKE_GENERIC_CONST_REAL(const_expr, name, `LONG_WIDTH_REAL)
 
 `define MAKE_CONST_REAL(const_expr, name) \
-    `MAKE_LONG_CONST_REAL(``const_expr``, ``name``)
+    `MAKE_LONG_CONST_REAL(const_expr, name)
 
 // multiplication of two variables
 
 `define MUL_INTO_REAL(a_name, b_name, c_name) \
     mul_real #( \
-        `PASS_REAL(a, ``a_name``), \
-        `PASS_REAL(b, ``b_name``), \
-        `PASS_REAL(c, ``c_name``) \
+        `PASS_REAL(a, a_name), \
+        `PASS_REAL(b, b_name), \
+        `PASS_REAL(c, c_name) \
     ) mul_real_``c_name``_i ( \
-        .a(``a_name``), \
-        .b(``b_name``), \
-        .c(``c_name``) \
+        .a(a_name), \
+        .b(b_name), \
+        .c(c_name) \
     )
         
 `define MUL_REAL_GENERIC(a_name, b_name, c_name, c_width) \
-    `MAKE_GENERIC_REAL(``c_name``, `RANGE_PARAM_REAL(``a_name``)*`RANGE_PARAM_REAL(``b_name``), ``c_width``); \
-    `MUL_INTO_REAL(``a_name``, ``b_name``, ``c_name``)
+    `MAKE_GENERIC_REAL(c_name, `RANGE_PARAM_REAL(a_name)*`RANGE_PARAM_REAL(b_name), c_width); \
+    `MUL_INTO_REAL(a_name, b_name, c_name)
 
 `define MUL_REAL(a_name, b_name, c_name) \
-    `MUL_REAL_GENERIC(``a_name``, ``b_name``, ``c_name``, `LONG_WIDTH_REAL)
+    `MUL_REAL_GENERIC(a_name, b_name, c_name, `LONG_WIDTH_REAL)
 
 // multiplication of a constant and variable
 
 `define MUL_CONST_INTO_REAL_GENERIC(const_expr, in_name, out_name, const_width) \
-    `MAKE_GENERIC_CONST_REAL(``const_expr``, zzz_tmp_``out_name``, ``const_width``); \
-    `MUL_INTO_REAL(zzz_tmp_``out_name``, ``in_name``, ``out_name``)
+    `MAKE_GENERIC_CONST_REAL(const_expr, zzz_tmp_``out_name``, const_width); \
+    `MUL_INTO_REAL(zzz_tmp_``out_name``, in_name, out_name)
 
 `define MUL_CONST_INTO_REAL(const_expr, in_name, out_name) \
-    `MUL_CONST_INTO_REAL_GENERIC(``const_expr``, ``in_name``, ``out_name``, `SHORT_WIDTH_REAL)
+    `MUL_CONST_INTO_REAL_GENERIC(const_expr, in_name, out_name, `SHORT_WIDTH_REAL)
 
 `define MUL_CONST_REAL_GENERIC(const_expr, in_name, out_name, const_width, out_width) \
-    `MAKE_GENERIC_REAL(``out_name``, `CONST_RANGE_REAL(``const_expr``)*`RANGE_PARAM_REAL(``in_name``), ``out_width``); \
-    `MUL_CONST_INTO_REAL_GENERIC(``const_expr``, ``in_name``, ``out_name``, ``const_width``)
+    `MAKE_GENERIC_REAL(out_name, `CONST_RANGE_REAL(const_expr)*`RANGE_PARAM_REAL(in_name), out_width); \
+    `MUL_CONST_INTO_REAL_GENERIC(const_expr, in_name, out_name, const_width)
 
 `define MUL_CONST_REAL(const_expr, in_name, out_name) \
-    `MUL_CONST_REAL_GENERIC(``const_expr``, ``in_name``, ``out_name``, `SHORT_WIDTH_REAL, `LONG_WIDTH_REAL)
+    `MUL_CONST_REAL_GENERIC(const_expr, in_name, out_name, `SHORT_WIDTH_REAL, `LONG_WIDTH_REAL)
 
 // generic addition or subtraction
 
 `define ADD_SUB_INTO_REAL(opcode_value, a_name, b_name, c_name) \
     add_sub_real #( \
-        `PASS_REAL(a, ``a_name``), \
-        `PASS_REAL(b, ``b_name``), \
-        `PASS_REAL(c, ``c_name``), \
-		.opcode(``opcode_value``) \
+        `PASS_REAL(a, a_name), \
+        `PASS_REAL(b, b_name), \
+        `PASS_REAL(c, c_name), \
+		.opcode(opcode_value) \
     ) add_sub_real_``c_name``_i ( \
-        .a(``a_name``), \
-        .b(``b_name``), \
-        .c(``c_name``) \
+        .a(a_name), \
+        .b(b_name), \
+        .c(c_name) \
     )
 
 // addition of two variables
@@ -457,93 +454,93 @@ endfunction
 `define ADD_OPCODE_REAL 0
 
 `define ADD_INTO_REAL(a_name, b_name, c_name) \
-    `ADD_SUB_INTO_REAL(`ADD_OPCODE_REAL, ``a_name``, ``b_name``, ``c_name``)
+    `ADD_SUB_INTO_REAL(`ADD_OPCODE_REAL, a_name, b_name, c_name)
 
 `define ADD_REAL_GENERIC(a_name, b_name, c_name, c_width) \
-    `MAKE_GENERIC_REAL(``c_name``, `RANGE_PARAM_REAL(``a_name``) + `RANGE_PARAM_REAL(``b_name``), ``c_width``); \
-    `ADD_INTO_REAL(``a_name``, ``b_name``, ``c_name``)
+    `MAKE_GENERIC_REAL(c_name, `RANGE_PARAM_REAL(a_name) + `RANGE_PARAM_REAL(b_name), c_width); \
+    `ADD_INTO_REAL(a_name, b_name, c_name)
 
 `define ADD_REAL(a_name, b_name, c_name) \
-    `ADD_REAL_GENERIC(``a_name``, ``b_name``, ``c_name``, `LONG_WIDTH_REAL)
+    `ADD_REAL_GENERIC(a_name, b_name, c_name, `LONG_WIDTH_REAL)
     
 // addition of a constant and a variable
 
 `define ADD_CONST_INTO_REAL_GENERIC(const_expr, in_name, out_name, const_width) \
-    `MAKE_GENERIC_CONST_REAL(``const_expr``, zzz_tmp_``out_name``, ``const_width``); \
-    `ADD_INTO_REAL(zzz_tmp_``out_name``, ``in_name``, ``out_name``)
+    `MAKE_GENERIC_CONST_REAL(const_expr, zzz_tmp_``out_name``, const_width); \
+    `ADD_INTO_REAL(zzz_tmp_``out_name``, in_name, out_name)
 
 `define ADD_CONST_INTO_REAL(const_expr, in_name, out_name) \
-    `ADD_CONST_INTO_REAL_GENERIC(``const_expr``, ``in_name``, ``out_name``, `LONG_WIDTH_REAL)
+    `ADD_CONST_INTO_REAL_GENERIC(const_expr, in_name, out_name, `LONG_WIDTH_REAL)
 
 `define ADD_CONST_REAL_GENERIC(const_expr, in_name, out_name, const_width, out_width) \
-    `MAKE_GENERIC_REAL(``out_name``, `CONST_RANGE_REAL(``const_expr``) + `RANGE_PARAM_REAL(``in_name``), ``out_width``); \
-    `ADD_CONST_INTO_REAL_GENERIC(``const_expr``, ``in_name``, ``out_name``, ``const_width``)
+    `MAKE_GENERIC_REAL(out_name, `CONST_RANGE_REAL(const_expr) + `RANGE_PARAM_REAL(in_name), out_width); \
+    `ADD_CONST_INTO_REAL_GENERIC(const_expr, in_name, out_name, const_width)
 
 `define ADD_CONST_REAL(const_expr, in_name, out_name) \
-    `ADD_CONST_REAL_GENERIC(``const_expr``, ``in_name``, ``out_name``, `LONG_WIDTH_REAL, `LONG_WIDTH_REAL)
+    `ADD_CONST_REAL_GENERIC(const_expr, in_name, out_name, `LONG_WIDTH_REAL, `LONG_WIDTH_REAL)
 
 // addition of three variables
 
 `define ADD3_INTO_REAL_GENERIC(a_name, b_name, c_name, d_name, tmp_width) \
-    `ADD_REAL_GENERIC(``a_name``, ``b_name``, zzz_tmp_``d_name``, ``tmp_width``); \
-    `ADD_INTO_REAL(zzz_tmp_``d_name``, ``c_name``, ``d_name``)
+    `ADD_REAL_GENERIC(a_name, b_name, zzz_tmp_``d_name``, tmp_width); \
+    `ADD_INTO_REAL(zzz_tmp_``d_name``, c_name, d_name)
 
 `define ADD3_INTO_REAL(a_name, b_name, c_name, d_name) \
-    `ADD3_INTO_REAL_GENERIC(``a_name``, ``b_name``, ``c_name``, ``d_name``, `LONG_WIDTH_REAL)
+    `ADD3_INTO_REAL_GENERIC(a_name, b_name, c_name, d_name, `LONG_WIDTH_REAL)
 
 `define ADD3_REAL_GENERIC(a_name, b_name, c_name, d_name, tmp_width, d_width) \
-    `MAKE_GENERIC_REAL(``d_name``, `RANGE_PARAM_REAL(``a_name``) + `RANGE_PARAM_REAL(``b_name``) + `RANGE_PARAM_REAL(``c_name``), ``d_width``); \
-    `ADD3_INTO_REAL_GENERIC(``a_name``, ``b_name``, ``c_name``, ``d_name``, ``tmp_width``)
+    `MAKE_GENERIC_REAL(d_name, `RANGE_PARAM_REAL(a_name) + `RANGE_PARAM_REAL(b_name) + `RANGE_PARAM_REAL(c_name), d_width); \
+    `ADD3_INTO_REAL_GENERIC(a_name, b_name, c_name, d_name, tmp_width)
 
 `define ADD3_REAL(a_name, b_name, c_name, d_name) \
-    `ADD3_REAL_GENERIC(``a_name``, ``b_name``, ``c_name``, ``d_name``, `LONG_WIDTH_REAL, `LONG_WIDTH_REAL)
+    `ADD3_REAL_GENERIC(a_name, b_name, c_name, d_name, `LONG_WIDTH_REAL, `LONG_WIDTH_REAL)
 
 // subtraction of two variables
 
 `define SUB_OPCODE_REAL 1
 
 `define SUB_INTO_REAL(a_name, b_name, c_name) \
-    `ADD_SUB_INTO_REAL(`SUB_OPCODE_REAL, ``a_name``, ``b_name``, ``c_name``)
+    `ADD_SUB_INTO_REAL(`SUB_OPCODE_REAL, a_name, b_name, c_name)
 
 `define SUB_REAL_GENERIC(a_name, b_name, c_name, c_width) \
-    `MAKE_GENERIC_REAL(``c_name``, `RANGE_PARAM_REAL(``a_name``) + `RANGE_PARAM_REAL(``b_name``), ``c_width``); \
-    `SUB_INTO_REAL(``a_name``, ``b_name``, ``c_name``)
+    `MAKE_GENERIC_REAL(c_name, `RANGE_PARAM_REAL(a_name) + `RANGE_PARAM_REAL(b_name), c_width); \
+    `SUB_INTO_REAL(a_name, b_name, c_name)
 
 `define SUB_REAL(a_name, b_name, c_name) \
-    `SUB_REAL_GENERIC(``a_name``, ``b_name``, ``c_name``, `LONG_WIDTH_REAL)
+    `SUB_REAL_GENERIC(a_name, b_name, c_name, `LONG_WIDTH_REAL)
 
 // conditional assignment
 
 `define ITE_INTO_REAL(cond_name, true_name, false_name, out_name) \
     ite_real #( \
-        `PASS_REAL(true, ``true_name``), \
-        `PASS_REAL(false, ``false_name``), \
-        `PASS_REAL(out, ``out_name``) \
+        `PASS_REAL(true, true_name), \
+        `PASS_REAL(false, false_name), \
+        `PASS_REAL(out, out_name) \
     ) ite_real_``out_name``_i ( \
-        .cond(``cond_name``), \
-        .true(``true_name``), \
-        .false(``false_name``), \
-        .out(``out_name``) \
+        .cond(cond_name), \
+        .true(true_name), \
+        .false(false_name), \
+        .out(out_name) \
     )
 
 `define ITE_REAL_GENERIC(cond_name, true_name, false_name, out_name, out_width) \
-    `MAKE_GENERIC_REAL(``out_name``, `MAX_MATH(`RANGE_PARAM_REAL(``true_name``), `RANGE_PARAM_REAL(``false_name``)), ``out_width``); \
-    `ITE_INTO_REAL(``cond_name``, ``true_name``, ``false_name``, ``out_name``)
+    `MAKE_GENERIC_REAL(out_name, `MAX_MATH(`RANGE_PARAM_REAL(true_name), `RANGE_PARAM_REAL(false_name)), out_width); \
+    `ITE_INTO_REAL(cond_name, true_name, false_name, out_name)
 
 `define ITE_REAL(cond_name, true_name, false_name, out_name) \
-    `ITE_REAL_GENERIC(``cond_name``, ``true_name``, ``false_name``, ``out_name``, `LONG_WIDTH_REAL) \
+    `ITE_REAL_GENERIC(cond_name, true_name, false_name, out_name, `LONG_WIDTH_REAL) \
 
 // generic comparison
 
 `define COMP_INTO_REAL(opcode_value, a_name, b_name, c_name) \
     comp_real #( \
-        `PASS_REAL(a, ``a_name``), \
-        `PASS_REAL(b, ``b_name``), \
-        .opcode(``opcode_value``) \
+        `PASS_REAL(a, a_name), \
+        `PASS_REAL(b, b_name), \
+        .opcode(opcode_value) \
     ) comp_real_``c_name``_i ( \
-        .a(``a_name``), \
-        .b(``b_name``), \
-        .c(``c_name``) \
+        .a(a_name), \
+        .b(b_name), \
+        .c(c_name) \
     )
 
 // greater than
@@ -551,92 +548,92 @@ endfunction
 `define GT_OPCODE_REAL 0
 
 `define GT_INTO_REAL(a_name, b_name, c_name) \
-    `COMP_INTO_REAL(`GT_OPCODE_REAL, ``a_name``, ``b_name``, ``c_name``)
+    `COMP_INTO_REAL(`GT_OPCODE_REAL, a_name, b_name, c_name)
 
 `define GT_REAL(a_name, b_name, c_name) \
-    logic ``c_name``; \
-    `GT_INTO_REAL(``a_name``, ``b_name``, ``c_name``)
+    logic c_name; \
+    `GT_INTO_REAL(a_name, b_name, c_name)
 
 // greater than or equal to
 
 `define GE_OPCODE_REAL 1
 
 `define GE_INTO_REAL(a_name, b_name, c_name) \
-    `COMP_INTO_REAL(`GE_OPCODE_REAL, ``a_name``, ``b_name``, ``c_name``)
+    `COMP_INTO_REAL(`GE_OPCODE_REAL, a_name, b_name, c_name)
 
 `define GE_REAL(a_name, b_name, c_name) \
-    logic ``c_name``; \
-    `GE_INTO_REAL(``a_name``, ``b_name``, ``c_name``)
+    logic c_name; \
+    `GE_INTO_REAL(a_name, b_name, c_name)
 
 // less than
 
 `define LT_OPCODE_REAL 2
 
 `define LT_INTO_REAL(a_name, b_name, c_name) \
-    `COMP_INTO_REAL(`LT_OPCODE_REAL, ``a_name``, ``b_name``, ``c_name``)
+    `COMP_INTO_REAL(`LT_OPCODE_REAL, a_name, b_name, c_name)
 
 `define LT_REAL(a_name, b_name, c_name) \
-    logic ``c_name``; \
-    `LT_INTO_REAL(``a_name``, ``b_name``, ``c_name``)
+    logic c_name; \
+    `LT_INTO_REAL(a_name, b_name, c_name)
 
 // less than or equal to
 
 `define LE_OPCODE_REAL 3
 
 `define LE_INTO_REAL(a_name, b_name, c_name) \
-    `COMP_INTO_REAL(`LE_OPCODE_REAL, ``a_name``, ``b_name``, ``c_name``)
+    `COMP_INTO_REAL(`LE_OPCODE_REAL, a_name, b_name, c_name)
 
 `define LE_REAL(a_name, b_name, c_name) \
-    logic ``c_name``; \
-    `LE_INTO_REAL(``a_name``, ``b_name``, ``c_name``)
+    logic c_name; \
+    `LE_INTO_REAL(a_name, b_name, c_name)
 
 // equal to
 
 `define EQ_OPCODE_REAL 4
 
 `define EQ_INTO_REAL(a_name, b_name, c_name) \
-    `COMP_INTO_REAL(`EQ_OPCODE_REAL, ``a_name``, ``b_name``, ``c_name``)
+    `COMP_INTO_REAL(`EQ_OPCODE_REAL, a_name, b_name, c_name)
 
 `define EQ_REAL(a_name, b_name, c_name) \
-    logic ``c_name``; \
-    `EQ_INTO_REAL(``a_name``, ``b_name``, ``c_name``)
+    logic c_name; \
+    `EQ_INTO_REAL(a_name, b_name, c_name)
 
 // not equal to
 
 `define NE_OPCODE_REAL 5
 
 `define NE_INTO_REAL(a_name, b_name, c_name) \
-    `COMP_INTO_REAL(`NE_OPCODE_REAL, ``a_name``, ``b_name``, ``c_name``)
+    `COMP_INTO_REAL(`NE_OPCODE_REAL, a_name, b_name, c_name)
 
 `define NE_REAL(a_name, b_name, c_name) \
-    logic ``c_name``; \
-    `NE_INTO_REAL(``a_name``, ``b_name``, ``c_name``)
+    logic c_name; \
+    `NE_INTO_REAL(a_name, b_name, c_name)
 
 // max of two variables
 
 `define MAX_INTO_REAL(a_name, b_name, c_name) \
-    `GT_REAL(``a_name``, ``b_name``, zzz_tmp_``c_name``); \
-    `ITE_INTO_REAL(zzz_tmp_``c_name``, ``a_name``, ``b_name``, ``c_name``)
+    `GT_REAL(a_name, b_name, zzz_tmp_``c_name``); \
+    `ITE_INTO_REAL(zzz_tmp_``c_name``, a_name, b_name, c_name)
 
 `define MAX_REAL_GENERIC(a_name, b_name, c_name, c_width) \
-    `MAKE_GENERIC_REAL(``c_name``, `MAX_MATH(`RANGE_PARAM_REAL(``a_name``), `RANGE_PARAM_REAL(``b_name``)), ``c_width``); \
-    `MAX_INTO_REAL(``a_name``, ``b_name``, ``c_name``)
+    `MAKE_GENERIC_REAL(c_name, `MAX_MATH(`RANGE_PARAM_REAL(a_name), `RANGE_PARAM_REAL(b_name)), c_width); \
+    `MAX_INTO_REAL(a_name, b_name, c_name)
 
 `define MAX_REAL(a_name, b_name, c_name) \
-    `MAX_REAL_GENERIC(``a_name``, ``b_name``, ``c_name``, `LONG_WIDTH_REAL)
+    `MAX_REAL_GENERIC(a_name, b_name, c_name, `LONG_WIDTH_REAL)
 
 // min of two variables
 
 `define MIN_INTO_REAL(a_name, b_name, c_name) \
-    `LT_REAL(``a_name``, ``b_name``, zzz_tmp_``c_name``); \
-    `ITE_INTO_REAL(zzz_tmp_``c_name``, ``a_name``, ``b_name``, ``c_name``)
+    `LT_REAL(a_name, b_name, zzz_tmp_``c_name``); \
+    `ITE_INTO_REAL(zzz_tmp_``c_name``, a_name, b_name, c_name)
 
 `define MIN_REAL_GENERIC(a_name, b_name, c_name, c_width) \
-    `MAKE_GENERIC_REAL(``c_name``, `MAX_MATH(`RANGE_PARAM_REAL(``a_name``), `RANGE_PARAM_REAL(``b_name``)), ``c_width``); \
-    `MIN_INTO_REAL(``a_name``, ``b_name``, ``c_name``)
+    `MAKE_GENERIC_REAL(c_name, `MAX_MATH(`RANGE_PARAM_REAL(a_name), `RANGE_PARAM_REAL(b_name)), c_width); \
+    `MIN_INTO_REAL(a_name, b_name, c_name)
 
 `define MIN_REAL(a_name, b_name, c_name) \
-    `MIN_REAL_GENERIC(``a_name``, ``b_name``, ``c_name``, `LONG_WIDTH_REAL)
+    `MIN_REAL_GENERIC(a_name, b_name, c_name, `LONG_WIDTH_REAL)
 
 // conversion from real number to integer
 // note that this always rounds down, regardless of whether HARD_FLOAT
@@ -644,106 +641,106 @@ endfunction
 
 `define REAL_TO_INT(in_name, int_width_expr, out_name) \
     `ifdef FLOAT_REAL \
-        logic signed[((``int_width_expr``)-1):0] ``out_name``; \
-        assign ``out_name`` = $floor(``in_name``) \
+        logic signed[((int_width_expr)-1):0] out_name; \
+        assign out_name = $floor(in_name) \
     `elsif HARD_FLOAT \
-        logic signed[((``int_width_expr``)-1):0] ``out_name``; \
+        logic signed[((int_width_expr)-1):0] out_name; \
         recFNToIN #( \
             .expWidth(`HARD_FLOAT_EXP_WIDTH), \
             .sigWidth(`HARD_FLOAT_SIG_WIDTH), \
-            .intWidth(``int_width_expr``) \
+            .intWidth(int_width_expr) \
         ) recFNToIN_``out_name``_i ( \
             .control(`HARD_FLOAT_CONTROL), \
-            .in(``in_name``), \
+            .in(in_name), \
             .roundingMode(`round_min), \
             .signedOut(1'b1), \
-            .out(``out_name``), \
+            .out(out_name), \
             .intExceptionFlags() \
         ) \
     `else \
-        `REAL_FROM_WIDTH_EXP(``out_name``, ``int_width_expr``, 0); \
-        `ASSIGN_REAL(``in_name``, ``out_name``) \
+        `REAL_FROM_WIDTH_EXP(out_name, int_width_expr, 0); \
+        `ASSIGN_REAL(in_name, out_name) \
     `endif
 
 `define REAL_INTO_INT(in_name, int_width_expr, out_name) \
-    `REAL_TO_INT(``in_name``, ``int_width_expr``, zzz_tmp_``out_name``); \
-    assign ``out_name`` = zzz_tmp_``out_name``
+    `REAL_TO_INT(in_name, int_width_expr, zzz_tmp_``out_name``); \
+    assign out_name = zzz_tmp_``out_name``
     
 // conversion from integer to real number
 
 `define INT_TO_REAL(in_name, int_width_expr, out_name) \
-    `REAL_FROM_WIDTH_EXP(``out_name``, ``int_width_expr``, 0); \
+    `REAL_FROM_WIDTH_EXP(out_name, int_width_expr, 0); \
     `ifdef FLOAT_REAL \
-        assign ``out_name`` = 1.0*(``in_name``) \
+        assign out_name = 1.0*(in_name) \
     `elsif HARD_FLOAT \
         iNToRecFN #( \
-            .intWidth(``int_width_expr``), \
+            .intWidth(int_width_expr), \
             .expWidth(`HARD_FLOAT_EXP_WIDTH), \
             .sigWidth(`HARD_FLOAT_SIG_WIDTH) \
         ) iNToRecFN_``out_name``_i ( \
             .control(`HARD_FLOAT_CONTROL), \
             .signedIn(1'b1), \
-            .in(``in_name``), \
+            .in(in_name), \
             .roundingMode(`HARD_FLOAT_ROUNDING), \
-            .out(``out_name``), \
+            .out(out_name), \
             .exceptionFlags() \
         ) \
     `else \
-        assign ``out_name`` = ``in_name`` \
+        assign out_name = in_name \
     `endif
     
 `define INT_INTO_REAL(in_name, int_width_expr, out_name) \
-    `INT_TO_REAL(``in_name``, ``int_width_expr``, zzz_tmp_``out_name``); \
-    `ASSIGN_REAL(zzz_tmp_``out_name``, ``out_name``)
+    `INT_TO_REAL(in_name, int_width_expr, zzz_tmp_``out_name``); \
+    `ASSIGN_REAL(zzz_tmp_``out_name``, out_name)
 
 // get the width of an integer
 
 `define MEAS_UINT_WIDTH_INTO(in_name, in_width_expr, out_name, out_width_expr) \
     meas_uint_width #( \
-        .in_width(``in_width_expr``), \
-        .out_width(``out_width_expr``) \
+        .in_width(in_width_expr), \
+        .out_width(out_width_expr) \
     ) meas_uint_width_``out_name`` ( \
-        .in(``in_name``), \
-        .out(``out_name``) \
+        .in(in_name), \
+        .out(out_name) \
     )
 
 `define MEAS_UINT_WIDTH(in_name, in_width_expr, out_name, out_width_expr) \
-    logic [((``out_width_expr)-1):0] out_name; \
-    `MEAS_UINT_WIDTH_INTO(``in_name``, ``in_width_expr``, ``out_name``, ``out_width_expr``)
+    logic [((out_width_expr)-1):0] out_name; \
+    `MEAS_UINT_WIDTH_INTO(in_name, in_width_expr, out_name, out_width_expr)
 
 // compressing an integer into a real number using an approximately logarithmic mapping
 
 `define COMPRESS_UINT_INTO(in_name, in_width_expr, out_name) \
     compress_uint #( \
-        .in_width(``in_width_expr``), \
-        `PASS_REAL(out, ``out_name``) \
+        .in_width(in_width_expr), \
+        `PASS_REAL(out, out_name) \
     ) compress_uint_``out_name``_i ( \
-        .in(``in_name``), \
-        .out(``out_name``) \
+        .in(in_name), \
+        .out(out_name) \
     )
 
 `define COMPRESS_UINT(in_name, in_width_expr, out_name) \
-    `MAKE_REAL(``out_name``, ((``in_width_expr``)+1)); \
-    `COMPRESS_UINT_INTO(``in_name``, ``in_width_expr``, ``out_name``)
+    `MAKE_REAL(out_name, ((in_width_expr)+1)); \
+    `COMPRESS_UINT_INTO(in_name, in_width_expr, out_name)
 
 // memory
 
 `define DFF_INTO_REAL(d_name, q_name, rst_name, clk_name, cke_name, init_expr) \
     dff_real #( \
-        `PASS_REAL(d, ``d_name``), \
-        `PASS_REAL(q, ``q_name``), \
-        .init(``init_expr``) \
+        `PASS_REAL(d, d_name), \
+        `PASS_REAL(q, q_name), \
+        .init(init_expr) \
     ) dff_real_``q_name``_i ( \
-        .d(``d_name``), \
-        .q(``q_name``), \
-        .rst(``rst_name``), \
-        .clk(``clk_name``), \
-        .cke(``cke_name``) \
+        .d(d_name), \
+        .q(q_name), \
+        .rst(rst_name), \
+        .clk(clk_name), \
+        .cke(cke_name) \
     )
 
 `define DFF_REAL(d_name, q_name, rst_name, clk_name, cke_name, init_expr) \
-    `COPY_FORMAT_REAL(``d_name``, ``q_name``); \
-    `DFF_INTO_REAL(``d_name``, ``q_name``, ``rst_name``, ``clk_name``, ``cke_name``, ``init_expr``)
+    `COPY_FORMAT_REAL(d_name, q_name); \
+    `DFF_INTO_REAL(d_name, q_name, rst_name, clk_name, cke_name, init_expr)
 
 // synchronous ROM
 // note that the data_bits_expr input is ignored when HARD_FLOAT is defined, because HARD_FLOAT
@@ -813,78 +810,78 @@ endfunction
 // maximum range for the width and exponent must be used
 
 `define INTF_DECL_REAL(name) \
-    parameter integer `WIDTH_PARAM_REAL(``name``)=0, \
-    parameter integer `EXPONENT_PARAM_REAL(``name``)=0
+    parameter integer `WIDTH_PARAM_REAL(name)=0, \
+    parameter integer `EXPONENT_PARAM_REAL(name)=0
 
 `define REAL_INTF_PARAMS(name, width_expr, exponent_expr) \
-    .`WIDTH_PARAM_REAL(``name``)(``width_expr``), \
-    .`EXPONENT_PARAM_REAL(``name``)(``exponent_expr``)
+    .`WIDTH_PARAM_REAL(name)(width_expr), \
+    .`EXPONENT_PARAM_REAL(name)(exponent_expr)
 
 `define INTF_FORMAT_REAL(name) ``name``_format_signal
 
  `define INTF_MAKE_REAL(name) \
-     `DATA_TYPE_REAL(`WIDTH_PARAM_REAL(``name``)) ``name``; \
-     logic [((`WIDTH_PARAM_REAL(``name``))+(`EXPONENT_PARAM_REAL(``name``))-1):(`EXPONENT_PARAM_REAL(``name``))] `INTF_FORMAT_REAL(``name``)
+     `DATA_TYPE_REAL(`WIDTH_PARAM_REAL(name)) name; \
+     logic [((`WIDTH_PARAM_REAL(name))+(`EXPONENT_PARAM_REAL(name))-1):(`EXPONENT_PARAM_REAL(name))] `INTF_FORMAT_REAL(name)
  
-`define INTF_WIDTH_REAL(name) ($size(`INTF_FORMAT_REAL(``name``)))
+`define INTF_WIDTH_REAL(name) ($size(`INTF_FORMAT_REAL(name)))
 
-`define INTF_EXPONENT_REAL(name) ($low(`INTF_FORMAT_REAL(``name``)))
+`define INTF_EXPONENT_REAL(name) ($low(`INTF_FORMAT_REAL(name)))
 
-`define INTF_RANGE_REAL(name) (2.0**($high(`INTF_FORMAT_REAL(``name``))))
+`define INTF_RANGE_REAL(name) (2.0**($high(`INTF_FORMAT_REAL(name))))
 
 `define INTF_PASS_REAL(port, name) \
-    .`WIDTH_PARAM_REAL(``port``)(`INTF_WIDTH_REAL(``name``)), \
-    .`EXPONENT_PARAM_REAL(``port``)(`INTF_EXPONENT_REAL(``name``)), \
-    .`RANGE_PARAM_REAL(``port``)(`INTF_RANGE_REAL(``name``))
+    .`WIDTH_PARAM_REAL(port)(`INTF_WIDTH_REAL(name)), \
+    .`EXPONENT_PARAM_REAL(port)(`INTF_EXPONENT_REAL(name)), \
+    .`RANGE_PARAM_REAL(port)(`INTF_RANGE_REAL(name))
 
 `define INTF_ALIAS_REAL(path, name) \
-    `MAKE_FORMAT_REAL(``name``, `INTF_RANGE_REAL(``path``), `INTF_WIDTH_REAL(``path``), `INTF_EXPONENT_REAL(``path``))
+    `MAKE_FORMAT_REAL(name, `INTF_RANGE_REAL(path), `INTF_WIDTH_REAL(path), `INTF_EXPONENT_REAL(path))
 
 `define INTF_INPUT_TO_REAL(path, name) \
-    `INTF_ALIAS_REAL(``path``, ``name``); \
-    assign ``name`` = ``path``
+    `INTF_ALIAS_REAL(path, name); \
+    assign name = path
 
 `define INTF_OUTPUT_TO_REAL(path, name) \
-    `INTF_ALIAS_REAL(``path``, ``name``); \
-    assign ``path`` = ``name``
+    `INTF_ALIAS_REAL(path, name); \
+    assign path = name
 
 // modport-related functions
 
 `define MODPORT_IN_REAL(name) \
-    input ``name``, \
-    input `INTF_FORMAT_REAL(``name``)
+    input name, \
+    input `INTF_FORMAT_REAL(name)
 
 `define MODPORT_OUT_REAL(name) \
-    output ``name``, \
-    input `INTF_FORMAT_REAL(``name``)
+    output name, \
+    input `INTF_FORMAT_REAL(name)
 
 // print a real number (interface version)
 
 `define INTF_TO_REAL(name) \
     `ifdef FLOAT_REAL \
-        (``name``) \
+        (name) \
     `elsif HARD_FLOAT \
-        (`REC_FN_TO_REAL(``name``)) \
+        (`REC_FN_TO_REAL(name)) \
     `else \
-        (`FIXED_TO_FLOAT((``name``), `INTF_EXPONENT_REAL(``name``))) \
+        (`FIXED_TO_FLOAT((name), `INTF_EXPONENT_REAL(name))) \
     `endif
  
 `define INTF_PRINT_REAL(name) \
-    $display(`"``name``=%0f`", `INTF_TO_REAL(``name``))
+    $display(`"``name``=%0f`", `INTF_TO_REAL(name))
 
 // force a real number (interface version)
 
 `define INTF_FROM_REAL(expr, name) \
     `ifdef FLOAT_REAL \
-        (``expr``) \
+        (expr) \
     `elsif HARD_FLOAT \
-        (`REAL_TO_REC_FN(``expr``)) \
+        (`REAL_TO_REC_FN(expr)) \
     `else \
-		(`FLOAT_TO_FIXED((``expr``), `INTF_EXPONENT_REAL(``name``))) \
+		(`FLOAT_TO_FIXED((expr), `INTF_EXPONENT_REAL(name))) \
     `endif
 
 `define INTF_FORCE_REAL(expr, name) \
-    ``name`` = `INTF_FROM_REAL(``expr``, ``name``)
+    name = `INTF_FROM_REAL(expr, name)
 
 // module definitions
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,5 +1,6 @@
 # generic imports
-from shutil import which
+from copy import deepcopy
+from shutil import which, copyfile
 from pathlib import Path
 
 # AHA imports
@@ -27,15 +28,19 @@ def get_dirs(*args):
     # alias for get_files
     return get_files(*args)
 
-def pytest_sim_params(metafunc, simulators=None):
+def pytest_sim_params(metafunc, simulators=None, skip=None):
+    # set defaults
+    if skip is None:
+        skip = []
     if simulators is None:
-        simulators = ['vcs', 'vivado', 'ncsim', 'iverilog']
+        #simulators = ['vcs', 'vivado', 'ncsim', 'iverilog']
+        simulators = ['verilator']
 
     # parameterize with the simulators available
     if 'simulator' in metafunc.fixturenames:
         targets = []
         for simulator in simulators:
-            if which(simulator):
+            if (simulator not in skip) and which(simulator):
                 targets.append(simulator)
 
         metafunc.parametrize('simulator', targets)
@@ -148,26 +153,32 @@ def run_vivado_tcl(tcl_file, cwd=None, err_str=None, disp_type='realtime'):
     return subprocess_run(cmd, cwd=cwd, err_str=err_str, disp_type=disp_type)
 
 class SvrealTester(fault.Tester):
-    def __init__(self, circuit, clock=None, expect_strict_default=True, debug_mode=False):
-        super().__init__(circuit=circuit, clock=clock,
-                         expect_strict_default=expect_strict_default)
-        self.debug_mode = debug_mode
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
-    def compile_and_run(self, target='system-verilog', ext_srcs=None,
-                        inc_dirs=None, ext_model_file=True, tmp_dir=None,
-                        disp_type=None, real_type=RealType.FixedPoint,
-                        defines=None, **kwargs):
+    def compile_and_run(self, ext_model_file, simulator='iverilog',
+                        ext_srcs=None, inc_dirs=None, disp_type='on_error',
+                        real_type=RealType.FixedPoint, defines=None,
+                        directory='build', **kwargs):
+        # copy kwargs
+        kwargs = deepcopy(kwargs)
+        if 'flags' not in kwargs:
+            kwargs['flags'] = []
+
         # set defaults
         if ext_srcs is None:
             ext_srcs = []
         if inc_dirs is None:
             inc_dirs = []
-        if tmp_dir is None:
-            tmp_dir = not self.debug_mode
-        if disp_type is None:
-            disp_type = 'on_error' if (not self.debug_mode) else 'realtime'
         if defines is None:
             defines = {}
+
+        # set the target type
+        if simulator == 'verilator':
+            target = 'verilator'
+        else:
+            target = 'system-verilog'
+            kwargs['simulator'] = simulator
 
         # add to ext_srcs
         if real_type == RealType.HardFloat:
@@ -179,7 +190,7 @@ class SvrealTester(fault.Tester):
             inc_dirs = get_hard_float_inc_dirs() + inc_dirs
 
         # add defines as needed for the real number type
-        defines = defines.copy()
+        defines = deepcopy(defines)
         if real_type == RealType.FixedPoint:
             pass
         elif real_type == RealType.FloatReal:
@@ -187,14 +198,36 @@ class SvrealTester(fault.Tester):
         elif real_type == RealType.HardFloat:
             defines['HARD_FLOAT'] = None
 
+        # map arguments depending on simulator type
+        if target == 'verilator':
+            # prepare arguments lists
+            for k, v in defines.items():
+                if v is not None:
+                    kwargs['flags'] += [f'-D{k}={v}']
+                else:
+                    kwargs['flags'] += [f'-D{k}']
+            kwargs['include_directories'] = inc_dirs
+            kwargs['include_verilog_libraries'] = ext_srcs
+            kwargs['skip_compile'] = True
+
+            # determine file extension
+            if Path(ext_model_file).suffix == '.sv':
+                kwargs['magma_opts'] = {'sv': None}
+
+            # copy in files
+            Path(directory).mkdir(exist_ok=True, parents=True)
+            copyfile(str(ext_model_file), str(Path(directory) / Path(ext_model_file).name))
+        else:
+            kwargs['defines'] = defines
+            kwargs['inc_dirs'] = inc_dirs
+            kwargs['ext_srcs'] = ext_srcs + [ext_model_file]
+            kwargs['ext_model_file'] = True
+
         # call the command
         super().compile_and_run(
-            target='system-verilog',
-            ext_srcs=ext_srcs,
-            inc_dirs=inc_dirs,
-            defines=defines,
-            ext_model_file=ext_model_file,
-            tmp_dir=tmp_dir,
+            target=target,
+            directory=directory,
+            tmp_dir=False,
             disp_type=disp_type,
             **kwargs
         )

--- a/tests/common.py
+++ b/tests/common.py
@@ -210,6 +210,10 @@ class SvrealTester(fault.Tester):
             kwargs['include_verilog_libraries'] = ext_srcs
             kwargs['skip_compile'] = True
 
+            # disable some warnings
+            kwargs['flags'] += ['-Wno-WIDTH']
+            kwargs['flags'] += ['-Wno-REALCVT']
+
             # determine file extension
             if Path(ext_model_file).suffix == '.sv':
                 kwargs['magma_opts'] = {'sv': None}

--- a/tests/test_arith.py
+++ b/tests/test_arith.py
@@ -68,7 +68,7 @@ def test_arith(simulator, real_type):
 
     # run the test
     tester.compile_and_run(
+        get_file('test_arith.sv'),
         simulator=simulator,
-        ext_srcs=[get_file('test_arith.sv')],
         real_type=real_type
     )

--- a/tests/test_clog2.py
+++ b/tests/test_clog2.py
@@ -46,6 +46,6 @@ def test_clog2(simulator):
         run_iteration(1.1**e)
 
     tester.compile_and_run(
-        simulator=simulator,
-        ext_srcs=[get_file('test_clog2.sv')]
+        get_file('test_clog2.sv'),
+        simulator=simulator
     )

--- a/tests/test_comp.py
+++ b/tests/test_comp.py
@@ -6,7 +6,7 @@ import fault
 from .common import *
 
 def pytest_generate_tests(metafunc):
-    pytest_sim_params(metafunc)
+    pytest_sim_params(metafunc, skip=['verilator'])
     pytest_real_type_params(metafunc)
 
 def model_func(a_i, b_i):

--- a/tests/test_comp.py
+++ b/tests/test_comp.py
@@ -69,7 +69,7 @@ def test_comp(simulator, real_type):
 
     # run the test
     tester.compile_and_run(
+        get_file('test_comp.sv'),
         simulator=simulator,
-        ext_srcs=[get_file('test_comp.sv')],
         real_type=real_type
     )

--- a/tests/test_compress_uint.py
+++ b/tests/test_compress_uint.py
@@ -72,8 +72,8 @@ def test_compress_uint(simulator, real_type, width, test_vec):
         t.expect(dut.out, model_func(in_), abs_tol=1e-5)
 
     t.compile_and_run(
+        get_file('test_compress_uint.sv'),
         simulator=simulator,
-        ext_srcs=[get_file('test_compress_uint.sv')],
         defines={'WIDTH': width},
         real_type=real_type
     )

--- a/tests/test_compress_uint.py
+++ b/tests/test_compress_uint.py
@@ -9,7 +9,7 @@ import magma as m
 from .common import *
 
 def pytest_generate_tests(metafunc):
-    pytest_sim_params(metafunc)
+    pytest_sim_params(metafunc, skip=['verilator'])
     pytest_real_type_params(metafunc)
 
     # set up test vectors

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -53,8 +53,8 @@ def test_const(simulator, real_type):
 
     # run the test
     tester.compile_and_run(
+        get_file('test_const.sv'),
         simulator=simulator,
-        ext_srcs=[get_file('test_const.sv')],
         parameters=parameters,
         real_type=real_type
     )

--- a/tests/test_conv.py
+++ b/tests/test_conv.py
@@ -63,7 +63,7 @@ def test_conv(simulator, real_type):
 
     # run the test
     tester.compile_and_run(
+        get_file('test_conv.sv'),
         simulator=simulator,
-        ext_srcs=[get_file('test_conv.sv')],
         real_type=real_type
     )

--- a/tests/test_dff.py
+++ b/tests/test_dff.py
@@ -72,8 +72,8 @@ def test_dff(simulator, real_type):
 
     # run the test
     tester.compile_and_run(
+        get_file('test_dff.sv'),
         simulator=simulator,
-        ext_srcs=[get_file('test_dff.sv')],
         real_type=real_type,
         parameters={'init': 1.23}
     )

--- a/tests/test_float.py
+++ b/tests/test_float.py
@@ -5,7 +5,7 @@ import magma as m
 from .common import *
 
 def pytest_generate_tests(metafunc):
-    pytest_sim_params(metafunc)
+    pytest_sim_params(metafunc, skip=['verilator'])
 
 def test_float(simulator):
     # declare circuit
@@ -20,8 +20,8 @@ def test_float(simulator):
     t.eval()
 
     t.compile_and_run(
+        get_file('test_float.sv'),
         simulator=simulator,
-        ext_srcs=[get_file('test_float.sv')],
         ext_test_bench=True,
         real_type=RealType.HardFloat
     )

--- a/tests/test_hier.py
+++ b/tests/test_hier.py
@@ -30,7 +30,7 @@ def test_hier(simulator, real_type):
 
     # run the test
     tester.compile_and_run(
+        get_file('test_hier.sv'),
         simulator=simulator,
-        ext_srcs=[get_file('test_hier.sv')],
         real_type=real_type
     )

--- a/tests/test_iface.py
+++ b/tests/test_iface.py
@@ -31,9 +31,9 @@ def test_iface(simulator, real_type, defines):
 
     # run the test
     tester.compile_and_run(
+        get_file('test_iface.sv'),
         simulator=simulator,
-        ext_srcs=[get_file('test_iface_core.sv'),
-                  get_file('test_iface.sv')],
+        ext_srcs=[get_file('test_iface_core.sv')],
         real_type=real_type,
         defines=defines
     )

--- a/tests/test_iface.py
+++ b/tests/test_iface.py
@@ -6,7 +6,7 @@ import fault
 from .common import *
 
 def pytest_generate_tests(metafunc):
-    pytest_sim_params(metafunc, simulators=['ncsim', 'vcs', 'vivado'])
+    pytest_sim_params(metafunc, skip=['iverilog', 'verilator'])
     pytest_real_type_params(metafunc)
     metafunc.parametrize('defines', [None, {'INTF_USE_LOCAL': None}])
 

--- a/tests/test_ite.py
+++ b/tests/test_ite.py
@@ -53,7 +53,7 @@ def test_ite(simulator, real_type):
 
     # run the test
     tester.compile_and_run(
+        get_file('test_ite.sv'),
         simulator=simulator,
-        ext_srcs=[get_file('test_ite.sv')],
         real_type=real_type
     )

--- a/tests/test_meas_width.py
+++ b/tests/test_meas_width.py
@@ -34,6 +34,6 @@ def test_meas_width(simulator):
         t.expect(dut.out, model_func(in_))
 
     t.compile_and_run(
-        simulator=simulator,
-        ext_srcs=[get_file('test_meas_width.sv')]
+        get_file('test_meas_width.sv'),
+        simulator=simulator
     )

--- a/tests/test_sync_ram.py
+++ b/tests/test_sync_ram.py
@@ -64,8 +64,8 @@ def test_sync_ram(simulator, real_type):
 
     # run the test
     t.compile_and_run(
+        get_file('test_sync_ram.sv'),
         simulator=simulator,
-        ext_srcs=[get_file('test_sync_ram.sv')],
         real_type=real_type,
         defines={'WIDTH': width}
     )

--- a/tests/test_sync_rom.py
+++ b/tests/test_sync_rom.py
@@ -82,8 +82,8 @@ def test_sync_rom(simulator, real_type, abs_tol=0.001):
 
     # run the test
     t.compile_and_run(
+        get_file('test_sync_rom.sv'),
         simulator=simulator,
-        ext_srcs=[get_file('test_sync_rom.sv')],
         real_type=real_type,
         defines={'PATH_TO_MEM': f'"{path_to_mem}"'}
     )


### PR DESCRIPTION
This small PR adds Verilator support by fixing some instances of unsupported syntax in **svreal.sv**.  The main issue had to do with the use of double backticks (token delimiter) in some places where they weren't needed.  I also updated the regression tests to use **verilator** in addition to the simulators already supported.